### PR TITLE
Change player hashmaps to use a case insensitive string wrapper for the key

### DIFF
--- a/src/main/java/com/botdetector/model/CaseInsensitiveString.java
+++ b/src/main/java/com/botdetector/model/CaseInsensitiveString.java
@@ -1,0 +1,66 @@
+package com.botdetector.model;
+
+import lombok.Value;
+
+/**
+ * A string wrapper that makes .equals a caseInsensitive match
+ * <p>
+ *     a collection that wraps a String mapping in CaseInsensitiveStrings will still accept a String but will now
+ *     return a caseInsensitive match rather than a caseSensitive one
+ * </p>
+ * <p>
+ *     Yoinked from https://stackoverflow.com/questions/39026195/caseinsensitive-map-key-java
+ * </p>
+ */
+@Value
+public class CaseInsensitiveString
+{
+	String str;
+
+	public static CaseInsensitiveString wrap(String str)
+	{
+		return new CaseInsensitiveString(str);
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+
+		if (o == null)
+		{
+			return false;
+		}
+
+		if (o.getClass() == getClass())
+		{
+			// Is another CaseInsensitiveString
+			CaseInsensitiveString that = (CaseInsensitiveString) o;
+			return (str != null) ? str.equalsIgnoreCase(that.str) : that.str == null;
+		}
+
+		if (o.getClass() == String.class)
+		{
+			// Is just a regular String
+			String that = (String) o;
+			return str.equalsIgnoreCase(that);
+		}
+
+		return false;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return (str != null) ? str.toUpperCase().hashCode() : 0;
+	}
+
+	@Override
+	public String toString()
+	{
+		return str;
+	}
+}

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -3,6 +3,7 @@ package com.botdetector.ui;
 import com.botdetector.BotDetectorConfig;
 import com.botdetector.BotDetectorPlugin;
 import com.botdetector.http.BotDetectorClient;
+import com.botdetector.model.CaseInsensitiveString;
 import com.botdetector.model.PlayerSighting;
 import com.botdetector.model.PlayerStats;
 import com.botdetector.model.Prediction;
@@ -89,9 +90,9 @@ public class BotDetectorPanel extends PluginPanel
 	private final BotDetectorClient detectorClient;
 	private final BotDetectorConfig config;
 
-	private boolean searchBarLoading;
+	private final Set<JComponent> switchableFontComponents = new HashSet<>();
 
-	private Set<JComponent> switchableFontComponents = new HashSet<>();
+	private boolean searchBarLoading;
 
 	// Player Stats
 	private JLabel playerStatsUploadedNamesLabel;
@@ -642,7 +643,7 @@ public class BotDetectorPanel extends PluginPanel
 			if (shouldAllowFeedbackOrReport()
 				&& pred.getPlayerId() > 0)
 			{
-				String name = plugin.normalizePlayerName(pred.getPlayerName());
+				CaseInsensitiveString name = plugin.normalizeAndWrapPlayerName(pred.getPlayerName());
 				predictionFeedbackPanel.setVisible(!plugin.getFeedbackedPlayers().containsKey(name));
 				predictionReportPanel.setVisible(sighting != null && !plugin.getReportedPlayers().containsKey(name));
 			}
@@ -716,7 +717,7 @@ public class BotDetectorPanel extends PluginPanel
 				searchBar.setEditable(true);
 				searchBarLoading = false;
 
-				setPrediction(pred, plugin.getPersistentSightings().get(plugin.normalizePlayerName(target)));
+				setPrediction(pred, plugin.getPersistentSightings().get(plugin.normalizeAndWrapPlayerName(target)));
 			}));
 	}
 
@@ -783,7 +784,7 @@ public class BotDetectorPanel extends PluginPanel
 				{
 					plugin.sendChatStatusMessage("Thank you for your feedback!");
 					plugin.getFeedbackedPlayers().put(
-						plugin.normalizePlayerName(lastPrediction.getPlayerName()), feedback);
+						plugin.normalizeAndWrapPlayerName(lastPrediction.getPlayerName()), feedback);
 				}
 				else
 				{
@@ -801,7 +802,7 @@ public class BotDetectorPanel extends PluginPanel
 			return;
 		}
 
-		String name = plugin.normalizePlayerName(lastPredictionPlayerSighting.getPlayerName());
+		CaseInsensitiveString name = plugin.normalizeAndWrapPlayerName(lastPredictionPlayerSighting.getPlayerName());
 
 		if (!doReport)
 		{


### PR DESCRIPTION
Names will now be sent in their original casing.

On the plugin side, when looking up our hashmaps, as long as we wrap the name in the CaseInsensitiveString class, it won't matter if the casing changes (mostly for panel prediction lookups).