### PR TITLE
Fix a potential bug, a real bug and a potential crash

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -15,8 +15,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.SwingUtilities;
 import lombok.Getter;
 import net.runelite.api.ChatMessageType;
@@ -131,11 +131,11 @@ public class BotDetectorPlugin extends Plugin
 	// All map keys should get handled with normalizePlayerName() followed by toLowerCase()
 	private final Table<CaseInsensitiveString, Integer, PlayerSighting> sightingTable = Tables.synchronizedTable(HashBasedTable.create());
 	@Getter
-	private final Map<CaseInsensitiveString, PlayerSighting> persistentSightings = new HashMap<>();
+	private final Map<CaseInsensitiveString, PlayerSighting> persistentSightings = new ConcurrentHashMap<>();
 	@Getter
-	private final Map<CaseInsensitiveString, Boolean> feedbackedPlayers = new HashMap<>();
+	private final Map<CaseInsensitiveString, Boolean> feedbackedPlayers = new ConcurrentHashMap<>();
 	@Getter
-	private final Map<CaseInsensitiveString, Boolean> reportedPlayers = new HashMap<>();
+	private final Map<CaseInsensitiveString, Boolean> reportedPlayers = new ConcurrentHashMap<>();
 
 	@Override
 	protected void startUp()
@@ -486,11 +486,11 @@ public class BotDetectorPlugin extends Plugin
 				{
 					if (b)
 					{
-						sendChatStatusMessage("Discord verified for " + author + "!");
+						sendChatStatusMessage("Discord verified for '" + author + "'!");
 					}
 					else
 					{
-						sendChatStatusMessage("Could not verify Discord for " + author + ".");
+						sendChatStatusMessage("Could not verify Discord for '" + author + "'.");
 					}
 				});
 		}

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -777,19 +777,26 @@ public class BotDetectorPanel extends PluginPanel
 			return;
 		}
 
-		detectorClient.sendFeedback(lastPrediction, lastPredictionReporterName, true)
+		CaseInsensitiveString wrappedName = plugin.normalizeAndWrapPlayerName(lastPrediction.getPlayerName());
+		Map<CaseInsensitiveString, Boolean> feedbackMap = plugin.getFeedbackedPlayers();
+		feedbackMap.put(wrappedName, feedback);
+
+		detectorClient.sendFeedback(lastPrediction, lastPredictionReporterName, feedback)
 			.whenComplete((b, ex) ->
 			{
+				String message;
 				if (b)
 				{
-					plugin.sendChatStatusMessage("Thank you for your feedback!");
-					plugin.getFeedbackedPlayers().put(
-						plugin.normalizeAndWrapPlayerName(lastPrediction.getPlayerName()), feedback);
+					message = "Thank you for your feedback for '%s'!";
 				}
 				else
 				{
-					plugin.sendChatStatusMessage("Error sending your feedback.");
+					message = "Error sending your feedback for '%s'.";
+					// Didn't work so remove from feedback map
+					feedbackMap.remove(wrappedName);
 				}
+
+				plugin.sendChatStatusMessage(String.format(message, wrappedName));
 			});
 	}
 
@@ -802,26 +809,32 @@ public class BotDetectorPanel extends PluginPanel
 			return;
 		}
 
-		CaseInsensitiveString name = plugin.normalizeAndWrapPlayerName(lastPredictionPlayerSighting.getPlayerName());
+		CaseInsensitiveString wrappedName = plugin.normalizeAndWrapPlayerName(lastPredictionPlayerSighting.getPlayerName());
+		Map<CaseInsensitiveString, Boolean> reportMap = plugin.getReportedPlayers();
+		reportMap.put(wrappedName, doReport);
 
+		// Didn't want to report? Work is done!
 		if (!doReport)
 		{
-			plugin.getReportedPlayers().put(name, false);
 			return;
 		}
 
 		detectorClient.sendSighting(lastPredictionPlayerSighting, lastPredictionReporterName, true)
 			.whenComplete((b, ex) ->
 			{
+				String message;
 				if (b)
 				{
-					plugin.sendChatStatusMessage("Thank you for your report!");
-					plugin.getReportedPlayers().put(name, true);
+					message = "Thank you for your report for '%s'!";
 				}
 				else
 				{
-					plugin.sendChatStatusMessage("Error sending your report.");
+					message = "Error sending your report '%s'.";
+					// Didn't work so remove from report map
+					reportMap.remove(wrappedName);
 				}
+
+				plugin.sendChatStatusMessage(String.format(message, wrappedName));
 			});
 	}
 

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -787,11 +787,11 @@ public class BotDetectorPanel extends PluginPanel
 				String message;
 				if (b)
 				{
-					message = "Thank you for your feedback for '%s'!";
+					message = "Thank you for your prediction feedback for '%s'!";
 				}
 				else
 				{
-					message = "Error sending your feedback for '%s'.";
+					message = "Error sending your prediction feedback for '%s'.";
 					// Didn't work so remove from feedback map
 					feedbackMap.remove(wrappedName);
 				}


### PR DESCRIPTION
Potential bug: Double reporting if a prediction is set before a response from the server comes back for feedbacks and reports.

Real bug: Oh god all feedbacks were taken as +1...

Potential crash: Just making the hashmaps concurrent to avoid any potential crash with the panel threading.

Bonus: Add feedbacked/reported player name to chat message.