### PR TITLE
Apply WordUtils.capitalize to pred labels and right align % in breakdown

### DIFF
--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -38,6 +38,7 @@ import net.runelite.client.ui.components.IconTextField;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.Text;
+import org.apache.commons.text.WordUtils;
 
 public class BotDetectorPanel extends PluginPanel
 {
@@ -752,7 +753,7 @@ public class BotDetectorPanel extends PluginPanel
 			.sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
 			.forEach(e ->
 				sb.append("<tr><td>").append(normalizeLabel(e.getKey())).append(":</td>")
-				.append("<td style='padding-left:5;color:").append(ColorUtil.toHexColor(getPredictionColor(e.getValue())))
+				.append("<td style='padding-left:5;text-align:right;color:").append(ColorUtil.toHexColor(getPredictionColor(e.getValue())))
 				.append("'>").append(getPercentString(e.getValue())).append("</td></tr>"));
 
 		return sb.append(closingTags).toString();
@@ -760,7 +761,7 @@ public class BotDetectorPanel extends PluginPanel
 
 	private String normalizeLabel(String label)
 	{
-		return label.replace("_", " ").trim();
+		return WordUtils.capitalize(label.replace('_', ' ').trim(), ' ');
 	}
 
 	private String getPercentString(double percent)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45152844/116637288-75d02900-a931-11eb-8c2b-e4eebbda8ce6.png)
