### PR TITLE
Add upper range to auto send minutes and use guava to clamp

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -43,6 +43,7 @@ public interface BotDetectorConfig extends Config
 	String PANEL_FONT_TYPE_KEY = "panelFontType";
 
 	int AUTO_SEND_MINIMUM_MINUTES = 5;
+	int AUTO_SEND_MAXIMUM_MINUTES = 360;
 
 	@ConfigItem(
 		position = 1,
@@ -61,7 +62,7 @@ public interface BotDetectorConfig extends Config
 		name = "Send Names Every",
 		description = "Sets the amount of time between automatic name uploads."
 	)
-	@Range(min = AUTO_SEND_MINIMUM_MINUTES)
+	@Range(min = AUTO_SEND_MINIMUM_MINUTES, max = AUTO_SEND_MAXIMUM_MINUTES)
 	@Units(Units.MINUTES)
 	default int autoSendMinutes()
 	{

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -33,6 +33,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
+import com.google.common.primitives.Ints;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
@@ -229,8 +230,10 @@ public class BotDetectorPlugin extends Plugin
 
 	private void updateTimeToAutoSend()
 	{
-		timeToAutoSend = Instant.now().plusSeconds(
-			Math.max(config.autoSendMinutes(), BotDetectorConfig.AUTO_SEND_MINIMUM_MINUTES) * 60);
+		timeToAutoSend = Instant.now().plusSeconds(60L *
+			Ints.constrainToRange(config.autoSendMinutes(),
+				BotDetectorConfig.AUTO_SEND_MINIMUM_MINUTES,
+				BotDetectorConfig.AUTO_SEND_MAXIMUM_MINUTES));
 	}
 
 	@Schedule(period = AUTO_SEND_SCHEDULE_SECONDS,


### PR DESCRIPTION
`Ints.constrainToRange` is commonly used in the Runelite project, see examples here:
https://github.com/runelite/runelite/search?q=ints.constrain

Upper limit I chose is 6h, or the game's default force logout timer.