### PR TITLE
Added toggle to highlight predict option

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -39,6 +39,7 @@ public interface BotDetectorConfig extends Config
 	String ONLY_SEND_AT_LOGOUT_KEY = "sendAtLogout";
 	String AUTO_SEND_MINUTES_KEY = "autoSendMinutes";
 	String ADD_PREDICT_OPTION_KEY = "addDetectOption"; // I know it says detect, don't change it.
+	String HIGHLIGHT_PREDICT_KEY = "highlightPredictOption";
 	String ANONYMOUS_REPORTING_KEY = "enableAnonymousReporting";
 	String PANEL_FONT_TYPE_KEY = "panelFontType";
 	String AUTH_FULL_TOKEN_KEY = "authToken";
@@ -105,6 +106,17 @@ public interface BotDetectorConfig extends Config
 
 	@ConfigItem(
 		position = 6,
+		keyName = HIGHLIGHT_PREDICT_KEY,
+		name = "Highlight 'Predict' Option",
+		description = "When right-clicking on a player, the predict option will be highlighted to be easier to identify."
+	)
+	default boolean highlightPredictOption()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 7,
 		keyName = PANEL_FONT_TYPE_KEY,
 		name = "Panel Font Size",
 		description = "Sets the size of the label fields in the prediction panel."
@@ -115,7 +127,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = ANONYMOUS_REPORTING_KEY,
 		name = "Anonymous Uploading",
 		description = "Your name will not be included with your name uploads.<br>Disable if you'd like to track your contributions."

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -806,12 +806,14 @@ public class BotDetectorPlugin extends Plugin
 			null, new String[]{"Ok"}, "Ok");
 	}
 
-	private String getPredictOption() {
+	private String getPredictOption()
+	{
 		if (config.highlightPredictOption())
 		{
 			return ColorUtil.prependColorTag(PREDICT_OPTION, Color.RED);
 		}
-		else {
+		else
+		{
 			return PREDICT_OPTION;
 		}
 	}

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
 import com.google.common.primitives.Ints;
 import java.awt.Toolkit;
+import java.awt.Color;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -89,6 +90,7 @@ import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.Text;
@@ -234,7 +236,7 @@ public class BotDetectorPlugin extends Plugin
 
 		if (config.addPredictOption() && client != null)
 		{
-			menuManager.addPlayerMenuItem(PREDICT_OPTION);
+			menuManager.addPlayerMenuItem(getPredictOption());
 		}
 
 		updateTimeToAutoSend();
@@ -252,7 +254,7 @@ public class BotDetectorPlugin extends Plugin
 
 		if (config.addPredictOption() && client != null)
 		{
-			menuManager.removePlayerMenuItem(PREDICT_OPTION);
+			menuManager.removePlayerMenuItem(getPredictOption());
 		}
 
 		clientToolbar.removeNavigation(navButton);
@@ -397,14 +399,16 @@ public class BotDetectorPlugin extends Plugin
 
 		switch (event.getKey())
 		{
+			case BotDetectorConfig.HIGHLIGHT_PREDICT_KEY:
 			case BotDetectorConfig.ADD_PREDICT_OPTION_KEY:
 				if (client != null)
 				{
+					menuManager.removePlayerMenuItem(ColorUtil.prependColorTag(PREDICT_OPTION, Color.RED));
 					menuManager.removePlayerMenuItem(PREDICT_OPTION);
 
 					if (config.addPredictOption())
 					{
-						menuManager.addPlayerMenuItem(PREDICT_OPTION);
+						menuManager.addPlayerMenuItem(getPredictOption());
 					}
 				}
 				break;
@@ -660,7 +664,7 @@ public class BotDetectorPlugin extends Plugin
 			}
 
 			final MenuEntry predict = new MenuEntry();
-			predict.setOption(PREDICT_OPTION);
+			predict.setOption(getPredictOption());
 			predict.setTarget(event.getTarget());
 			predict.setType(MenuAction.RUNELITE.getId());
 			predict.setParam0(event.getActionParam0());
@@ -676,7 +680,7 @@ public class BotDetectorPlugin extends Plugin
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		if ((event.getMenuAction() == MenuAction.RUNELITE || event.getMenuAction() == MenuAction.RUNELITE_PLAYER)
-			&& event.getMenuOption().equals(PREDICT_OPTION))
+			&& event.getMenuOption().equals(getPredictOption()))
 		{
 			String name;
 			if (event.getMenuAction() == MenuAction.RUNELITE_PLAYER)
@@ -800,5 +804,15 @@ public class BotDetectorPlugin extends Plugin
 		JOptionPane.showOptionDialog(null, ep,
 			"Error starting Bot Detector!", JOptionPane.DEFAULT_OPTION, JOptionPane.ERROR_MESSAGE,
 			null, new String[]{"Ok"}, "Ok");
+	}
+
+	private String getPredictOption() {
+		if (config.highlightPredictOption())
+		{
+			return ColorUtil.prependColorTag(PREDICT_OPTION, Color.RED);
+		}
+		else {
+			return PREDICT_OPTION;
+		}
 	}
 }


### PR DESCRIPTION
Adding a toggle to make the predict option standout more from the right-click menu as described in https://github.com/Bot-detector/bot-detector/issues/30.
![highlight_predict](https://user-images.githubusercontent.com/35677466/117253327-1b453a00-ae15-11eb-9158-f5cac41f9361.png)
