### PR TITLE
Increment plugin version to 1.3.1-DEV

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 }
 
 group = 'com.botdetector'
-version = '1.3'
+version = '1.3.1-DEV'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Non-hub candidates should have the `-DEV` string at the end.

When pulling for the hub, create a commit to remove this string, then PR that commit hash.

When the hub PR is accepted, increment this and put the `-DEV` back.

Normally I'd put `-SNAPSHOT`, but it's too long when the panel is in `Bold` mode.