### PR TITLE
Add equipment item ids logging

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -53,6 +53,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -78,6 +79,7 @@ import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.events.WorldChanged;
+import net.runelite.api.kit.KitType;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatCommandManager;
@@ -538,8 +540,20 @@ public class BotDetectorPlugin extends Plugin
 		}
 
 		WorldPoint wp = WorldPoint.fromLocalInstance(client, player.getLocalLocation());
-		PlayerSighting p = new PlayerSighting(playerName,
-			wp, isCurrentWorldMembers, isCurrentWorldPVP, Instant.now());
+
+		// Get player's equipment item ids (botanicvelious/Equipment-Inspector)
+		Map<KitType, Integer> equipment = new HashMap<>();
+		for (KitType kitType : KitType.values())
+		{
+			int itemId = player.getPlayerComposition().getEquipmentId(kitType);
+			if (itemId >= 0)
+			{
+				equipment.put(kitType, itemId);
+			}
+		}
+
+		PlayerSighting p = new PlayerSighting(playerName, wp, equipment,
+			isCurrentWorldMembers, isCurrentWorldPVP, Instant.now());
 
 		synchronized (sightingTable)
 		{

--- a/src/main/java/com/botdetector/model/PlayerSighting.java
+++ b/src/main/java/com/botdetector/model/PlayerSighting.java
@@ -27,9 +27,11 @@ package com.botdetector.model;
 
 import com.google.gson.annotations.SerializedName;
 import java.time.Instant;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.kit.KitType;
 
 @Value
 @AllArgsConstructor
@@ -38,6 +40,7 @@ public class PlayerSighting
 	public PlayerSighting(
 		String playerName,
 		WorldPoint wp,
+		Map<KitType, Integer> equipmentMap,
 		boolean inMembersWorld,
 		boolean inPVPWorld,
 		Instant timestamp)
@@ -47,6 +50,7 @@ public class PlayerSighting
 			wp.getX(),
 			wp.getY(),
 			wp.getPlane(),
+			equipmentMap,
 			inMembersWorld,
 			inPVPWorld,
 			timestamp);
@@ -66,6 +70,9 @@ public class PlayerSighting
 
 	@SerializedName("z")
 	int plane;
+	
+	@SerializedName("equipment")
+	Map<KitType, Integer> equipment;
 
 	@SerializedName("on_members_world")
 	boolean inMembersWorld;


### PR DESCRIPTION
Draft until we agree on how to send this and how it will be stored in the API

Example:
```
  {
    "reported": "Spoonami",
    "region_id": 11571,
    "x": 2936,
    "y": 3281,
    "z": 0,
    "equipment": {
      "AMULET": 19547,
      "HANDS": 7462,
      "TORSO": 11828,
      "WEAPON": 20997,
      "CAPE": 9757,
      "LEGS": 11830,
      "HEAD": 19645,
      "BOOTS": 22954
    },
    "on_members_world": 1,
    "on_pvp_world": 0,
    "ts": 1620316965,
    "reporter": "Cyborger1"
  }
```