### PR TITLE
Add equipment item ids logging

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -54,6 +54,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,6 +82,7 @@ import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.events.WorldChanged;
+import net.runelite.api.kit.KitType;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatCommandManager;
@@ -559,9 +561,20 @@ public class BotDetectorPlugin extends Plugin
 			return;
 		}
 
+		// Get player's equipment item ids (botanicvelious/Equipment-Inspector)
+		Map<KitType, Integer> equipment = new HashMap<>();
+		for (KitType kitType : KitType.values())
+		{
+			int itemId = player.getPlayerComposition().getEquipmentId(kitType);
+			if (itemId >= 0)
+			{
+				equipment.put(kitType, itemId);
+			}
+		}
+
 		WorldPoint wp = WorldPoint.fromLocalInstance(client, player.getLocalLocation());
-		PlayerSighting p = new PlayerSighting(playerName, wp, currentWorldNumber,
-			isCurrentWorldMembers, isCurrentWorldPVP, Instant.now());
+		PlayerSighting p = new PlayerSighting(playerName, wp, equipment,
+			currentWorldNumber, isCurrentWorldMembers, isCurrentWorldPVP, Instant.now());
 
 		synchronized (sightingTable)
 		{

--- a/src/main/java/com/botdetector/model/PlayerSighting.java
+++ b/src/main/java/com/botdetector/model/PlayerSighting.java
@@ -27,9 +27,11 @@ package com.botdetector.model;
 
 import com.google.gson.annotations.SerializedName;
 import java.time.Instant;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.kit.KitType;
 
 @Value
 @AllArgsConstructor
@@ -38,6 +40,7 @@ public class PlayerSighting
 	public PlayerSighting(
 		String playerName,
 		WorldPoint wp,
+		Map<KitType, Integer> equipmentMap,
 		int worldNumber,
 		boolean inMembersWorld,
 		boolean inPVPWorld,
@@ -48,6 +51,7 @@ public class PlayerSighting
 			wp.getX(),
 			wp.getY(),
 			wp.getPlane(),
+			equipmentMap,
 			worldNumber,
 			inMembersWorld,
 			inPVPWorld,
@@ -68,6 +72,9 @@ public class PlayerSighting
 
 	@SerializedName("z")
 	int plane;
+
+	@SerializedName("equipment")
+	Map<KitType, Integer> equipment;
 
 	@SerializedName("world_number")
 	int worldNumber;


### PR DESCRIPTION
Accidently closed the other one and it wouldn't let me re-open

Draft until we agree on how to send this and how it will be stored in the API

Example:
```
  {
    "reported": "Spoonami",
    "region_id": 11571,
    "x": 2936,
    "y": 3281,
    "z": 0,
    "equipment": {
      "AMULET": 19547,
      "HANDS": 7462,
      "TORSO": 11828,
      "WEAPON": 20997,
      "CAPE": 9757,
      "LEGS": 11830,
      "HEAD": 19645,
      "BOOTS": 22954
    },
    "on_members_world": 1,
    "on_pvp_world": 0,
    "ts": 1620316965,
    "reporter": "Cyborger1"
  }
```