### PR TITLE
Add total equipment GE value logging

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -91,6 +91,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -168,6 +169,9 @@ public class BotDetectorPlugin extends Plugin
 
 	@Inject
 	private MenuManager menuManager;
+
+	@Inject
+	private ItemManager itemManager;
 
 	@Inject
 	private BotDetectorConfig config;
@@ -563,18 +567,32 @@ public class BotDetectorPlugin extends Plugin
 
 		// Get player's equipment item ids (botanicvelious/Equipment-Inspector)
 		Map<KitType, Integer> equipment = new HashMap<>();
+		int geValue = 0;
 		for (KitType kitType : KitType.values())
 		{
 			int itemId = player.getPlayerComposition().getEquipmentId(kitType);
 			if (itemId >= 0)
 			{
 				equipment.put(kitType, itemId);
+				// Use GE price, not Wiki price
+				geValue += itemManager.getItemPriceWithSource(itemId, false);
 			}
 		}
 
 		WorldPoint wp = WorldPoint.fromLocalInstance(client, player.getLocalLocation());
-		PlayerSighting p = new PlayerSighting(playerName, wp, equipment,
-			currentWorldNumber, isCurrentWorldMembers, isCurrentWorldPVP, Instant.now());
+		PlayerSighting p = PlayerSighting.builder()
+			.playerName(playerName)
+			.regionID(wp.getRegionID())
+			.worldX(wp.getX())
+			.worldY(wp.getY())
+			.plane(wp.getPlane())
+			.equipment(equipment)
+			.equipmentGEValue(geValue)
+			.timestamp(Instant.now())
+			.worldNumber(currentWorldNumber)
+			.inMembersWorld(isCurrentWorldMembers)
+			.inPVPWorld(isCurrentWorldPVP)
+			.build();
 
 		synchronized (sightingTable)
 		{

--- a/src/main/java/com/botdetector/model/PlayerSighting.java
+++ b/src/main/java/com/botdetector/model/PlayerSighting.java
@@ -28,36 +28,14 @@ package com.botdetector.model;
 import com.google.gson.annotations.SerializedName;
 import java.time.Instant;
 import java.util.Map;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
-import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.kit.KitType;
 
 @Value
-@AllArgsConstructor
+@Builder
 public class PlayerSighting
 {
-	public PlayerSighting(
-		String playerName,
-		WorldPoint wp,
-		Map<KitType, Integer> equipmentMap,
-		int worldNumber,
-		boolean inMembersWorld,
-		boolean inPVPWorld,
-		Instant timestamp)
-	{
-		this(playerName,
-			wp.getRegionID(),
-			wp.getX(),
-			wp.getY(),
-			wp.getPlane(),
-			equipmentMap,
-			worldNumber,
-			inMembersWorld,
-			inPVPWorld,
-			timestamp);
-	}
-
 	@SerializedName("reported")
 	String playerName;
 
@@ -75,6 +53,9 @@ public class PlayerSighting
 
 	@SerializedName("equipment")
 	Map<KitType, Integer> equipment;
+
+	@SerializedName("equipment_ge")
+	int equipmentGEValue;
 
 	@SerializedName("world_number")
 	int worldNumber;


### PR DESCRIPTION
Example:
```
  {
    "reported": "Sleepy Yoshi",
    "region_id": 12598,
    "x": 3168,
    "y": 3491,
    "z": 0,
    "equipment": {
      "LEGS": 12329,
      "HANDS": 11133,
      "HEAD": 4502,
      "SHIELD": 3842,
      "CAPE": 6568,
      "WEAPON": 4170,
      "TORSO": 13104,
      "BOOTS": 23389,
      "AMULET": 6585
    },
    "equipment_ge": 3697675,
    "world_number": 304,
    "on_members_world": 1,
    "on_pvp_world": 0,
    "ts": 1620594746,
    "reporter": "Cyborger1"
  },
```

From Equipment Inspector for reference:
![image](https://user-images.githubusercontent.com/45152844/117587105-3b614b80-b0ea-11eb-8bc0-f4dab2050428.png)
