### PR TITLE
Add right-click predict to in-game report option

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -99,6 +99,17 @@ public interface BotDetectorConfig extends Config
 
 	@ConfigItem(
 		position = 5,
+		keyName = "predictOnReport",
+		name = "'Predict' on Right-click 'Report'",
+		description = "Makes the in-game right-click 'Report' option also open the prediction panel."
+	)
+	default boolean predictOnReport()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 6,
 		keyName = "predictOptionCopyName",
 		name = "'Predict' Copy Name to Clipboard",
 		description = "Copies the player's name to the clipboard when right-click predicting a player."
@@ -109,7 +120,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = HIGHLIGHT_PREDICT_KEY,
 		name = "Highlight 'Predict' Option",
 		description = "When right-clicking on a player, the predict option will be highlighted to be easier to identify."
@@ -120,7 +131,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 7,
+			position = 8,
 			keyName = "autocomplete",
 			name = "Prediction Autocomplete",
 			description = "Autocomplete names when typing a name to predict"
@@ -131,7 +142,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = SHOW_FEEDBACK_TEXTBOX,
 		name = "Show Feedback Textbox",
 		description = "Show a textbox on the prediction feedback panel where you can explain your feedback to us."
@@ -142,7 +153,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 10,
 		keyName = "panelDefaultStatsType",
 		name = "Panel Default Stats Tab",
 		description = "Sets the initial player statistics tab in the prediction panel for when the plugin is launched."
@@ -153,7 +164,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = PANEL_FONT_TYPE_KEY,
 		name = "Panel Font Size",
 		description = "Sets the size of the label fields in the prediction panel."
@@ -164,7 +175,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 12,
 		keyName = ANONYMOUS_UPLOADING_KEY,
 		name = "Anonymous Uploading",
 		description = "Your name will not be included with your name uploads.<br>Disable if you'd like to track your contributions."

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -130,10 +130,17 @@ public class BotDetectorPlugin extends Plugin
 
 	private static final String PREDICT_OPTION = "Predict";
 	private static final String HIGHLIGHTED_PREDICT_OPTION = ColorUtil.prependColorTag(PREDICT_OPTION, Color.RED);
+	private static final String REPORT_OPTION = "Report";
 	private static final String KICK_OPTION = "Kick";
 	private static final String DELETE_OPTION = "Delete";
 	private static final ImmutableSet<String> AFTER_OPTIONS =
 		ImmutableSet.of("Message", "Add ignore", "Remove friend", DELETE_OPTION, KICK_OPTION);
+
+	private static final ImmutableSet<MenuAction> PLAYER_MENU_ACTIONS = ImmutableSet.of(
+		MenuAction.PLAYER_FIRST_OPTION, MenuAction.PLAYER_SECOND_OPTION, MenuAction.PLAYER_THIRD_OPTION, MenuAction.PLAYER_FOURTH_OPTION,
+		MenuAction.PLAYER_FIFTH_OPTION, MenuAction.PLAYER_SIXTH_OPTION, MenuAction.PLAYER_SEVENTH_OPTION, MenuAction.PLAYER_EIGTH_OPTION
+	);
+
 
 	private static final String VERIFY_DISCORD_COMMAND = "!code";
 	private static final Pattern VERIFY_DISCORD_CODE_PATTERN = Pattern.compile("\\d{4}");
@@ -757,11 +764,14 @@ public class BotDetectorPlugin extends Plugin
 	@Subscribe
 	private void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if ((event.getMenuAction() == MenuAction.RUNELITE || event.getMenuAction() == MenuAction.RUNELITE_PLAYER)
-			&& event.getMenuOption().endsWith(PREDICT_OPTION))
+		if (((event.getMenuAction() == MenuAction.RUNELITE || event.getMenuAction() == MenuAction.RUNELITE_PLAYER)
+				&& event.getMenuOption().endsWith(PREDICT_OPTION))
+			|| (config.predictOnReport() && (PLAYER_MENU_ACTIONS.contains(event.getMenuAction()) || event.getMenuAction() == MenuAction.CC_OP_LOW_PRIORITY)
+				&& event.getMenuOption().equals(REPORT_OPTION)))
 		{
 			String name;
-			if (event.getMenuAction() == MenuAction.RUNELITE_PLAYER)
+			if (event.getMenuAction() == MenuAction.RUNELITE_PLAYER
+				|| PLAYER_MENU_ACTIONS.contains(event.getMenuAction()))
 			{
 				Player player = client.getCachedPlayers()[event.getId()];
 


### PR DESCRIPTION
I can't think of another `CC_OP_LOW_PRIORITY` called `Report` so I *think* this should be fine.