### PR TITLE
Extend dynamic Predict Highlight to account feedback

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -979,7 +979,8 @@ public class BotDetectorPlugin extends Plugin
 			case ALL:
 				return HIGHLIGHTED_PREDICT_OPTION;
 			case NOT_REPORTED:
-				return flaggedPlayers.containsKey(normalizeAndWrapPlayerName(playerName)) ?
+				CaseInsensitiveString name = normalizeAndWrapPlayerName(playerName);
+				return (feedbackedPlayers.containsKey(name) || flaggedPlayers.containsKey(name)) ?
 					PREDICT_OPTION : HIGHLIGHTED_PREDICT_OPTION;
 			default:
 				return PREDICT_OPTION;

--- a/src/main/java/com/botdetector/ui/PredictHighlightMode.java
+++ b/src/main/java/com/botdetector/ui/PredictHighlightMode.java
@@ -34,8 +34,8 @@ public enum PredictHighlightMode
 	NONE("No Highlight"),
 	/** Always highlight the Predict player option. **/
 	ALL("Highlight All"),
-	/** Stop highlighting the Predict player option if the player has had an option selected in the panel flagging buttons. **/
-	NOT_REPORTED("Only Unflagged")
+	/** Stop highlighting the Predict player option if the player has had an option selected in the panel feedback or flagging buttons. **/
+	NOT_REPORTED("Not Voted/Flagged")
 	;
 
 	private final String name;


### PR DESCRIPTION
The predict option will now stop highlighting when either the feedback or flagging panels have been interacted with, not just the flagging panel.