### PR TITLE
Add '!bdstats' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Identifies bots by sending nearby players' information to a third-party machine 
 | Attempt Send on Close | Attempts to upload names when closing Runelite while being logged in. Take note that enabling this option may cause the client to take a long time to close if our servers are being unresponsive. |
 | Send Names Every *x* mins | Determines how often the information collected by the plugin is flushed to our servers. The maximum rate is once per 5 minutes. | 
 | Enable Chat Status Messages | Inserts chat messages in your chatbox to inform you about your uploads being sent. |
+| '!bdstats' Chat Command Detail Level | Enable processing the '!bdstats' command when it appears in the chatbox, which will fetch the message author's plugin stats and display them. Disable to reduce spam. |
 | Right-click 'Predict' Players | Allows you to right-click predict players, instead of having to type their name in the Plugin's panel manually. |
 | 'Predict' on Right-click 'Report' | If you right-click Report someone via Jagex's official in-game report system, the player will be automatically predicted in the Plugin's Panel. |
 | 'Predict' Copy Name to Clipboard | Copies the predicted player's name to your clipboard when right-click predicting. |

--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -26,6 +26,7 @@
 package com.botdetector;
 
 import com.botdetector.model.PlayerStatsType;
+import com.botdetector.model.StatsCommandDetailLevel;
 import com.botdetector.ui.PanelFontType;
 import com.botdetector.ui.PredictHighlightMode;
 import net.runelite.client.config.Config;
@@ -104,6 +105,18 @@ public interface BotDetectorConfig extends Config
 
 	@ConfigItem(
 		position = 5,
+		keyName = "statsChatCommandDetailLevel",
+		name = "'!bdstats' Chat Command Detail Level",
+		description = "Enable processing the '!bdstats' command when it appears in the chatbox,"
+			+ "<br>which will fetch the message author's plugin stats and display them."
+	)
+	default StatsCommandDetailLevel statsChatCommandDetailLevel()
+	{
+		return StatsCommandDetailLevel.CONFIRMED_ONLY;
+	}
+
+	@ConfigItem(
+		position = 6,
 		keyName = ADD_PREDICT_OPTION_KEY,
 		name = "Right-click 'Predict' Players",
 		description = "Adds an entry to player menus to quickly check them in the prediction panel."
@@ -114,7 +127,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "predictOnReport",
 		name = "'Predict' on Right-click 'Report'",
 		description = "Makes the in-game right-click 'Report' option also open the prediction panel."
@@ -125,7 +138,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 8,
 		keyName = "predictOptionCopyName",
 		name = "'Predict' Copy Name to Clipboard",
 		description = "Copies the player's name to the clipboard when right-click predicting a player."
@@ -136,7 +149,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 9,
 		keyName = HIGHLIGHT_PREDICT_KEY,
 		name = "Highlight 'Predict' Option",
 		description = "When right-clicking on a player, the predict option will be highlighted to be easier to identify."
@@ -147,7 +160,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 9,
+			position = 10,
 			keyName = "autocomplete",
 			name = "Prediction Autocomplete",
 			description = "Autocomplete names when typing a name to predict in the prediction panel."
@@ -158,7 +171,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 10,
+		position = 11,
 		keyName = SHOW_FEEDBACK_TEXTBOX,
 		name = "Show Feedback Textbox",
 		description = "Show a textbox on the prediction feedback panel where you can explain your feedback to us."
@@ -169,7 +182,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 11,
+		position = 12,
 		keyName = "panelDefaultStatsType",
 		name = "Panel Default Stats Tab",
 		description = "Sets the initial player statistics tab in the prediction panel for when the plugin is launched."
@@ -180,7 +193,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 13,
 		keyName = PANEL_FONT_TYPE_KEY,
 		name = "Panel Font Size",
 		description = "Sets the size of the label fields in the prediction panel."
@@ -191,7 +204,7 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = ANONYMOUS_UPLOADING_KEY,
 		name = "Anonymous Uploading",
 		description = "Your name will not be included with your name uploads.<br>Disable if you'd like to track your contributions."

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -859,18 +859,17 @@ public class BotDetectorPlugin extends Plugin
 				if (ex == null && map != null)
 				{
 					PlayerStats totalStats = map.get(PlayerStatsType.TOTAL);
-					PlayerStats manualStats = map.get(PlayerStatsType.MANUAL);
-
-					if (totalStats == null && manualStats == null)
-					{
-						return;
-					}
 
 					ChatMessageBuilder response = new ChatMessageBuilder()
 						.append(ChatColorType.HIGHLIGHT)
 						.append("Bot Detector stats -");
 
-					if (totalStats != null)
+					if (totalStats == null || totalStats.getNamesUploaded() <= 0)
+					{
+						response.append(ChatColorType.NORMAL)
+							.append(" No plugin stats for this player");
+					}
+					else
 					{
 						if (detailLevel == StatsCommandDetailLevel.DETAILED)
 						{
@@ -887,33 +886,32 @@ public class BotDetectorPlugin extends Plugin
 								.append(ChatColorType.HIGHLIGHT)
 								.append(String.format(" %,d", totalStats.getPossibleBans()));
 						}
+
 						response.append(ChatColorType.NORMAL)
 							.append(" Confirmed Bans:")
 							.append(ChatColorType.HIGHLIGHT)
 							.append(String.format(" %,d", totalStats.getConfirmedBans()));
-					}
 
-					if (manualStats != null && manualStats.getNamesUploaded() > 0)
-					{
-						if (detailLevel == StatsCommandDetailLevel.DETAILED)
+						PlayerStats manualStats = map.get(PlayerStatsType.MANUAL);
+						if (manualStats != null && manualStats.getNamesUploaded() > 0)
 						{
+							if (detailLevel == StatsCommandDetailLevel.DETAILED)
+							{
+								response.append(ChatColorType.NORMAL)
+									.append(" Manual Flags:")
+									.append(ChatColorType.HIGHLIGHT)
+									.append(String.format(" %,d", manualStats.getNamesUploaded()))
+									.append(ChatColorType.NORMAL)
+									.append(" Manual Possible Bans:")
+									.append(ChatColorType.HIGHLIGHT)
+									.append(String.format(" %,d", manualStats.getPossibleBans()));
+							}
+
 							response.append(ChatColorType.NORMAL)
-								.append(" Manual Flags:")
+								.append(" Manual Confirmed Bans:")
 								.append(ChatColorType.HIGHLIGHT)
-								.append(String.format(" %,d", manualStats.getNamesUploaded()))
-								.append(ChatColorType.NORMAL)
-								.append(" Manual Possible Bans:")
-								.append(ChatColorType.HIGHLIGHT)
-								.append(String.format(" %,d", manualStats.getPossibleBans()));
-						}
+								.append(String.format(" %,d", manualStats.getConfirmedBans()));
 
-						response.append(ChatColorType.NORMAL)
-							.append(" Manual Confirmed Bans:")
-							.append(ChatColorType.HIGHLIGHT)
-							.append(String.format(" %,d", manualStats.getConfirmedBans()));
-
-						if (detailLevel == StatsCommandDetailLevel.DETAILED)
-						{
 							response.append(ChatColorType.NORMAL)
 								.append(" Manual Flag Accuracy:")
 								.append(ChatColorType.HIGHLIGHT)

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -33,6 +33,9 @@ import com.botdetector.model.AuthTokenType;
 import com.botdetector.model.CaseInsensitiveString;
 import com.botdetector.model.FeedbackValue;
 import com.botdetector.model.PlayerSighting;
+import com.botdetector.model.PlayerStats;
+import com.botdetector.model.PlayerStatsType;
+import com.botdetector.model.StatsCommandDetailLevel;
 import com.botdetector.ui.BotDetectorPanel;
 import com.botdetector.events.BotDetectorPanelActivated;
 import com.google.common.collect.EvictingQueue;
@@ -50,6 +53,7 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -75,6 +79,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.MessageNode;
 import net.runelite.api.Player;
 import net.runelite.api.WorldType;
 import net.runelite.api.coords.WorldPoint;
@@ -88,6 +93,7 @@ import net.runelite.api.events.PlayerSpawned;
 import net.runelite.api.events.WorldChanged;
 import net.runelite.api.kit.KitType;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatColorType;
 import net.runelite.client.chat.ChatCommandManager;
 import net.runelite.client.chat.ChatMessageBuilder;
@@ -154,6 +160,8 @@ public class BotDetectorPlugin extends Plugin
 	private static final int VERIFY_DISCORD_CODE_SIZE = 4;
 	private static final Pattern VERIFY_DISCORD_CODE_PATTERN = Pattern.compile("\\d{1," + VERIFY_DISCORD_CODE_SIZE + "}");
 
+	private static final String STATS_CHAT_COMMAND = "!bdstats";
+
 	private static final String COMMAND_PREFIX = "bd";
 	private static final String MANUAL_FLUSH_COMMAND = COMMAND_PREFIX + "Flush";
 	private static final String MANUAL_SIGHT_COMMAND = COMMAND_PREFIX + "Snap";
@@ -190,6 +198,9 @@ public class BotDetectorPlugin extends Plugin
 
 	@Inject
 	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private ConfigManager configManager;
@@ -357,6 +368,7 @@ public class BotDetectorPlugin extends Plugin
 		previousTwoGameStates.offer(client.getGameState());
 
 		chatCommandManager.registerCommand(VERIFY_DISCORD_COMMAND, this::verifyDiscord);
+		chatCommandManager.registerCommand(STATS_CHAT_COMMAND, this::statsChatCommand);
 	}
 
 	@Override
@@ -387,6 +399,7 @@ public class BotDetectorPlugin extends Plugin
 		previousTwoGameStates.clear();
 
 		chatCommandManager.unregisterCommand(VERIFY_DISCORD_COMMAND);
+		chatCommandManager.unregisterCommand(STATS_CHAT_COMMAND);
 	}
 
 	/**
@@ -808,6 +821,115 @@ public class BotDetectorPlugin extends Plugin
 				else if (config.showDiscordVerificationErrors())
 				{
 					sendChatStatusMessage("Could not verify Discord for '" + author + "'" + (ex != null ? ": " + ex.getMessage() : "."), true);
+				}
+			});
+	}
+
+	/**
+	 * Displays the Bot Detector statistics for the message's author
+	 * @param chatMessage The ChatMessage event object.
+	 * @param message The actual chat message.
+	 */
+	private void statsChatCommand(ChatMessage chatMessage, String message)
+	{
+		if (message.length() != STATS_CHAT_COMMAND.length())
+		{
+			return;
+		}
+
+		final StatsCommandDetailLevel detailLevel = config.statsChatCommandDetailLevel();
+		if (detailLevel == StatsCommandDetailLevel.OFF)
+		{
+			return;
+		}
+
+		final String author;
+		if (chatMessage.getType().equals(ChatMessageType.PRIVATECHATOUT))
+		{
+			author = loggedPlayerName;
+		}
+		else
+		{
+			author = Text.sanitize(chatMessage.getName());
+		}
+
+		detectorClient.requestPlayerStats(author)
+			.whenComplete((map, ex) ->
+			{
+				if (ex == null && map != null)
+				{
+					PlayerStats totalStats = map.get(PlayerStatsType.TOTAL);
+					PlayerStats manualStats = map.get(PlayerStatsType.MANUAL);
+
+					if (totalStats == null && manualStats == null)
+					{
+						return;
+					}
+
+					ChatMessageBuilder response = new ChatMessageBuilder()
+						.append(ChatColorType.HIGHLIGHT)
+						.append("Bot Detector stats - ");
+
+					if (totalStats != null)
+					{
+						if (detailLevel == StatsCommandDetailLevel.DETAILED)
+						{
+							response.append(ChatColorType.NORMAL)
+								.append("Total Uploads: ")
+								.append(ChatColorType.HIGHLIGHT)
+								.append(String.format("%,d ", totalStats.getNamesUploaded()))
+								.append(ChatColorType.NORMAL)
+								.append("Feedback Sent: ")
+								.append(ChatColorType.HIGHLIGHT)
+								.append(String.format("%,d ", totalStats.getFeedbackSent()))
+								.append(ChatColorType.NORMAL)
+								.append("Possible Bans: ")
+								.append(ChatColorType.HIGHLIGHT)
+								.append(String.format("%,d ", totalStats.getPossibleBans()));
+						}
+						response.append(ChatColorType.NORMAL)
+							.append("Confirmed Bans: ")
+							.append(ChatColorType.HIGHLIGHT)
+							.append(String.format("%,d ", totalStats.getConfirmedBans()));
+					}
+
+					if (manualStats != null && manualStats.getNamesUploaded() > 0)
+					{
+						if (detailLevel == StatsCommandDetailLevel.DETAILED)
+						{
+							response.append(ChatColorType.NORMAL)
+								.append("Manual Flags: ")
+								.append(ChatColorType.HIGHLIGHT)
+								.append(String.format("%,d ", manualStats.getNamesUploaded()))
+								.append(ChatColorType.NORMAL)
+								.append("Manual Possible Bans: ")
+								.append(ChatColorType.HIGHLIGHT)
+								.append(String.format("%,d ", manualStats.getPossibleBans()));
+						}
+
+						response.append(ChatColorType.NORMAL)
+							.append("Manual Confirmed Bans: ")
+							.append(ChatColorType.HIGHLIGHT)
+							.append(String.format("%,d ", manualStats.getConfirmedBans()));
+
+						if (detailLevel == StatsCommandDetailLevel.DETAILED)
+						{
+							response.append(ChatColorType.NORMAL)
+								.append("Manual Flag Accuracy: ")
+								.append(ChatColorType.HIGHLIGHT)
+								.append(new DecimalFormat("0.00%").format(manualStats.getAccuracy()));
+						}
+					}
+
+					final String builtResponse = response.build();
+					final MessageNode messageNode = chatMessage.getMessageNode();
+
+					clientThread.invokeLater(() ->
+					{
+						messageNode.setRuneLiteFormatMessage(builtResponse);
+						chatMessageManager.update(messageNode);
+						client.refreshChat();
+					});
 				}
 			});
 	}

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -868,29 +868,29 @@ public class BotDetectorPlugin extends Plugin
 
 					ChatMessageBuilder response = new ChatMessageBuilder()
 						.append(ChatColorType.HIGHLIGHT)
-						.append("Bot Detector stats - ");
+						.append("Bot Detector stats -");
 
 					if (totalStats != null)
 					{
 						if (detailLevel == StatsCommandDetailLevel.DETAILED)
 						{
 							response.append(ChatColorType.NORMAL)
-								.append("Total Uploads: ")
+								.append(" Total Uploads:")
 								.append(ChatColorType.HIGHLIGHT)
-								.append(String.format("%,d ", totalStats.getNamesUploaded()))
+								.append(String.format(" %,d", totalStats.getNamesUploaded()))
 								.append(ChatColorType.NORMAL)
-								.append("Feedback Sent: ")
+								.append(" Feedback Sent:")
 								.append(ChatColorType.HIGHLIGHT)
-								.append(String.format("%,d ", totalStats.getFeedbackSent()))
+								.append(String.format(" %,d", totalStats.getFeedbackSent()))
 								.append(ChatColorType.NORMAL)
-								.append("Possible Bans: ")
+								.append(" Possible Bans:")
 								.append(ChatColorType.HIGHLIGHT)
-								.append(String.format("%,d ", totalStats.getPossibleBans()));
+								.append(String.format(" %,d", totalStats.getPossibleBans()));
 						}
 						response.append(ChatColorType.NORMAL)
-							.append("Confirmed Bans: ")
+							.append(" Confirmed Bans:")
 							.append(ChatColorType.HIGHLIGHT)
-							.append(String.format("%,d ", totalStats.getConfirmedBans()));
+							.append(String.format(" %,d", totalStats.getConfirmedBans()));
 					}
 
 					if (manualStats != null && manualStats.getNamesUploaded() > 0)
@@ -898,26 +898,26 @@ public class BotDetectorPlugin extends Plugin
 						if (detailLevel == StatsCommandDetailLevel.DETAILED)
 						{
 							response.append(ChatColorType.NORMAL)
-								.append("Manual Flags: ")
+								.append(" Manual Flags:")
 								.append(ChatColorType.HIGHLIGHT)
-								.append(String.format("%,d ", manualStats.getNamesUploaded()))
+								.append(String.format(" %,d", manualStats.getNamesUploaded()))
 								.append(ChatColorType.NORMAL)
-								.append("Manual Possible Bans: ")
+								.append(" Manual Possible Bans:")
 								.append(ChatColorType.HIGHLIGHT)
-								.append(String.format("%,d ", manualStats.getPossibleBans()));
+								.append(String.format(" %,d", manualStats.getPossibleBans()));
 						}
 
 						response.append(ChatColorType.NORMAL)
-							.append("Manual Confirmed Bans: ")
+							.append(" Manual Confirmed Bans:")
 							.append(ChatColorType.HIGHLIGHT)
-							.append(String.format("%,d ", manualStats.getConfirmedBans()));
+							.append(String.format(" %,d", manualStats.getConfirmedBans()));
 
 						if (detailLevel == StatsCommandDetailLevel.DETAILED)
 						{
 							response.append(ChatColorType.NORMAL)
-								.append("Manual Flag Accuracy: ")
+								.append(" Manual Flag Accuracy:")
 								.append(ChatColorType.HIGHLIGHT)
-								.append(new DecimalFormat("0.00%").format(manualStats.getAccuracy()));
+								.append(new DecimalFormat(" 0.00%").format(manualStats.getAccuracy()));
 						}
 					}
 

--- a/src/main/java/com/botdetector/model/StatsCommandDetailLevel.java
+++ b/src/main/java/com/botdetector/model/StatsCommandDetailLevel.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Ferrariic, Seltzer Bro, Cyborger1
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.botdetector.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StatsCommandDetailLevel
+{
+	OFF("Disabled"),
+	CONFIRMED_ONLY("Confirmed Bans"),
+	DETAILED("Detailed Stats")
+	;
+
+	private final String name;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Allows sharing plugin stats with other plugin users in-game. Works by calling the "Request Player Stats" API on the message's author.

![image](https://user-images.githubusercontent.com/45152844/126581785-0bc6318f-69fa-4d96-9d95-fbfd45cd1526.png)
![image](https://user-images.githubusercontent.com/45152844/126581791-f5720f6c-d409-4717-a669-3e7a7c884231.png)
![image](https://user-images.githubusercontent.com/45152844/126581795-a7f4d278-4493-4554-8cac-781515fdb422.png)