### PR TITLE
Change name normalization in Discord Verification

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -779,11 +779,11 @@ public class BotDetectorPlugin extends Plugin
 		String author;
 		if (chatMessage.getType().equals(ChatMessageType.PRIVATECHATOUT))
 		{
-			author = normalizePlayerName(loggedPlayerName);
+			author = loggedPlayerName;
 		}
 		else
 		{
-			author = normalizePlayerName(chatMessage.getName());
+			author = Text.sanitize(chatMessage.getName());
 		}
 
 		String code = message.substring(VERIFY_DISCORD_COMMAND.length() + 1).trim();


### PR DESCRIPTION
This should fix issues with people that have underscores and/or hyphens in their names. Ideally though, the API should *always* convert underscores and hyphens to spaces as they are all treated as the same in Jagex's systems. Case insensitivity seems to be handled correctly already, however.

Also this conflicts hard with #114, but I'll still leave it open for now as a draft.