### PR TITLE
Remove some padding on top of the plugin panel

### DIFF
--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -230,7 +230,7 @@ public class BotDetectorPanel extends PluginPanel
 		this.nameAutocompleter = nameAutocompleter;
 		this.eventBus = eventBus;
 
-		setBorder(new EmptyBorder(18, 10, 10, 10));
+		setBorder(new EmptyBorder(10, 10, 10, 10));
 		setBackground(BACKGROUND_COLOR);
 		setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 


### PR DESCRIPTION
Just makes the top part of the panel look a bit more balanced. The old margins were copied from the hiscore panel, but I don't think it's necessary for us to have the same.

Before:
![image](https://user-images.githubusercontent.com/45152844/127580713-eb4e90c3-a244-4daa-8b40-3f674871ceca.png)

After:
![image](https://user-images.githubusercontent.com/45152844/127580669-851dcf5a-5b80-49ee-ac50-c9c1b0a16d06.png)
