### PR TITLE
Rearrange config settings with sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,23 @@ Identifies bots by sending nearby players' information to a third-party machine 
 
 ## Using the Plugin
 ### The Plugin's Settings
-| Setting | Description |
-|:--------|:------------|
-| Send Names Only After Logout | Recommended for players with low bandwidth. |
-| Attempt Send on Close | Attempts to upload names when closing Runelite while being logged in. Take note that enabling this option may cause the client to take a long time to close if our servers are being unresponsive. |
-| Send Names Every *x* mins | Determines how often the information collected by the plugin is flushed to our servers. The maximum rate is once per 5 minutes. | 
-| Enable Chat Status Messages | Inserts chat messages in your chatbox to inform you about your uploads being sent. |
-| '!bdstats' Chat Command Detail Level | Enable processing the '!bdstats' command when it appears in the chatbox, which will fetch the message author's plugin stats and display them. Disable to reduce spam. |
-| Right-click 'Predict' Players | Allows you to right-click predict players, instead of having to type their name in the Plugin's panel manually. |
-| 'Predict' on Right-click 'Report' | If you right-click Report someone via Jagex's official in-game report system, the player will be automatically predicted in the Plugin's Panel. |
-| 'Predict' Copy Name to Clipboard | Copies the predicted player's name to your clipboard when right-click predicting. |
-| 'Predict' Default Color | If set, highlights unflagged/unfeedbacked players' 'Predict' option in the given color so that you can easily spot it on the in-game menu. |
-| 'Predict' Voted/Flagged Color | If set, highlights flagged/feedbacked players' 'Predict' option in the given color so that you can easily spot it on the in-game menu. |
-| Prediction Autocomplete | Allows for prediction auto-completion for dialogue box entry.
-| Show Feedback Textbox | Adds a textbox to the prediction feedback panel, so you can explain your choice in up to 250 characters. Make sure you type your feedback *before* you make your choice! |
-| Panel Default Stats Tab | Sets panel default stats tab when the Plugin turns on. |
-| Panel Font Size | Sets the font size of most of the Plugin's Panel elements. |
-| Anonymous Uploading | When enabled, your username will not be sent with your uploads. You also cannot manually flag players. |
+| Setting Type | Setting Name | Description |
+|:--------|:--------|:------------|
+| Upload Settings | Anonymous Uploading | When enabled, your username will not be sent with your uploads. You also cannot manually flag players. |
+| Upload Settings | Send Names Only After Logout | Recommended for players with low bandwidth. |
+| Upload Settings | Attempt Send on Close | Attempts to upload names when closing Runelite while being logged in. Take note that enabling this option may cause the client to take a long time to close if our servers are being unresponsive. |
+| Upload Settings | Send Names Every *x* mins | Determines how often the information collected by the plugin is flushed to our servers. The maximum rate is once per 5 minutes. | 
+| Panel Settings | Prediction Autocomplete | Allows for prediction auto-completion for dialogue box entry.
+| Panel Settings | Show Feedback Textbox | Adds a textbox to the prediction feedback panel, so you can explain your choice in up to 250 characters. Make sure you type your feedback *before* you make your choice! |
+| Panel Settings | Panel Default Stats Tab | Sets panel default stats tab when the Plugin turns on. |
+| Panel Settings | Panel Font Size | Sets the font size of most of the Plugin's Panel elements. |
+| 'Predict' Settings | Right-click 'Predict' Players | Allows you to right-click predict players, instead of having to type their name in the Plugin's panel manually. |
+| 'Predict' Settings | 'Predict' on Right-click 'Report' | If you right-click Report someone via Jagex's official in-game report system, the player will be automatically predicted in the Plugin's Panel. |
+| 'Predict' Settings | 'Predict' Copy Name to Clipboard | Copies the predicted player's name to your clipboard when right-click predicting. |
+| 'Predict' Settings | 'Predict' Default Color | If set, highlights unflagged/unfeedbacked players' 'Predict' option in the given color so that you can easily spot it on the in-game menu. |
+| 'Predict' Settings | 'Predict' Voted/Flagged Color | If set, highlights flagged/feedbacked players' 'Predict' option in the given color so that you can easily spot it on the in-game menu. |
+| Other Settings | Enable Chat Status Messages | Inserts chat messages in your chatbox to inform you about your uploads being sent. |
+| Other Settings | '!bdstats' Chat Command Detail Level | Enable processing the '!bdstats' command when it appears in the chatbox, which will fetch the message author's plugin stats and display them. Disable to reduce spam. |
 
 ### ⚠️ Anonymous Mode ⚠️
 **Anonymous Mode** is enabled by default, which means your username will not be sent with your uploads. However, we cannot tally your uploads, and you will not be able to manually flag players.

--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -70,7 +70,7 @@ public interface BotDetectorConfig extends Config
 	@ConfigSection(
 		position = 3,
 		name = "'Predict' Settings",
-		description = "Settings for 'Predict' right-click option."
+		description = "Settings for the 'Predict' right-click option."
 	)
 	String predictSection = "predictSection";
 

--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -32,6 +32,7 @@ import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Range;
 import net.runelite.client.config.Units;
 
@@ -52,13 +53,54 @@ public interface BotDetectorConfig extends Config
 	int AUTO_SEND_MINIMUM_MINUTES = 5;
 	int AUTO_SEND_MAXIMUM_MINUTES = 360;
 
+	@ConfigSection(
+		position = 1,
+		name = "Upload Settings",
+		description = "Settings for how the plugin uploads player data."
+	)
+	String uploadSection = "uploadSection";
+
+	@ConfigSection(
+		position = 2,
+		name = "Panel Settings",
+		description = "Settings for the plugin's panel."
+	)
+	String panelSection = "panelSection";
+
+	@ConfigSection(
+		position = 3,
+		name = "'Predict' Settings",
+		description = "Settings for 'Predict' right-click option."
+	)
+	String predictSection = "predictSection";
+
+	@ConfigSection(
+		position = 4,
+		name = "Other Settings",
+		description = "Other miscellaneous settings."
+	)
+	String miscSection = "miscSection";
+
 	@ConfigItem(
 		position = 1,
+		keyName = ANONYMOUS_UPLOADING_KEY,
+		name = "Anonymous Uploading",
+		description = "Your name will not be included with your name uploads.<br>Disable if you'd like to track your contributions.",
+		section = uploadSection
+	)
+	default boolean enableAnonymousUploading()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 2,
 		keyName = ONLY_SEND_AT_LOGOUT_KEY,
 		name = "Send Names Only After Logout",
 		description = "Waits to upload names until you've logged out. Use this if you have a poor connection."
-			+ "<br><span style='color:red'>WARNING:</span> Names <b>will not</b> be sent if Runelite is closed completely"
-			+ "<br>before logging out, unless 'Attempt Send on Close' is turned on."
+			+ "<br><span style='color:red'>WARNING:</span> Names <b>will not</b> be sent if RuneLite is closed completely"
+			+ "<br>before logging out, unless 'Attempt Send on Close' is turned on.",
+		section = uploadSection
 	)
 	default boolean onlySendAtLogout()
 	{
@@ -66,12 +108,13 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
+		position = 3,
 		keyName = "uploadOnShutdown",
 		name = "Attempt Send on Close",
-		description = "Attempts to upload names when closing Runelite while being logged in."
+		description = "Attempts to upload names when closing RuneLite while being logged in."
 			+ "<br><span style='color:red'>WARNING:</span> This may cause the client to take significantly longer to close"
-			+ "<br>in the event that the Bot Detector server is being slow or unresponsive."
+			+ "<br>in the event that the Bot Detector server is being slow or unresponsive.",
+		section = uploadSection
 	)
 	default boolean uploadOnShutdown()
 	{
@@ -79,10 +122,11 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 4,
 		keyName = AUTO_SEND_MINUTES_KEY,
 		name = "Send Names Every",
-		description = "Sets the amount of time between automatic name uploads."
+		description = "Sets the amount of time between automatic name uploads.",
+		section = uploadSection
 	)
 	@Range(min = AUTO_SEND_MINIMUM_MINUTES, max = AUTO_SEND_MAXIMUM_MINUTES)
 	@Units(Units.MINUTES)
@@ -92,82 +136,11 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
-		keyName = "enableChatNotifications",
-		name = "Enable Chat Status Messages",
-		description = "Show various plugin status messages in the game chat."
-	)
-	default boolean enableChatStatusMessages()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 5,
-		keyName = "statsChatCommandDetailLevel",
-		name = "'!bdstats' Chat Command Detail Level",
-		description = "Enable processing the '!bdstats' command when it appears in the chatbox,"
-			+ "<br>which will fetch the message author's plugin stats and display them."
-	)
-	default StatsCommandDetailLevel statsChatCommandDetailLevel()
-	{
-		return StatsCommandDetailLevel.CONFIRMED_ONLY;
-	}
-
-	@ConfigItem(
-		position = 6,
-		keyName = ADD_PREDICT_OPTION_KEY,
-		name = "Right-click 'Predict' Players",
-		description = "Adds an entry to player menus to quickly check them in the prediction panel."
-	)
-	default boolean addPredictOption()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 7,
-		keyName = "predictOnReport",
-		name = "'Predict' on Right-click 'Report'",
-		description = "Makes the in-game right-click 'Report' option also open the prediction panel."
-	)
-	default boolean predictOnReport()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 8,
-		keyName = "predictOptionCopyName",
-		name = "'Predict' Copy Name to Clipboard",
-		description = "Copies the player's name to the clipboard when right-click predicting a player."
-	)
-	default boolean predictOptionCopyName()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 9,
-		keyName = "predictOptionDefaultColor",
-		name = "'Predict' Default Color",
-		description = "When right-clicking on a player, the predict option will be this color by default."
-	)
-	Color predictOptionDefaultColor();
-
-	@ConfigItem(
-		position = 10,
-		keyName = "predictOptionFlaggedColor",
-		name = "'Predict' Voted/Flagged Color",
-		description = "When right-clicking on a player that has been flagged or given feedback, the predict option will be this color instead."
-	)
-	Color predictOptionFlaggedColor();
-
-	@ConfigItem(
-			position = 11,
-			keyName = "autocomplete",
-			name = "Prediction Autocomplete",
-			description = "Autocomplete names when typing a name to predict in the prediction panel."
+		position = 1,
+		keyName = "autocomplete",
+		name = "Prediction Autocomplete",
+		description = "Autocomplete names when typing a name to predict in the prediction panel.",
+		section = panelSection
 	)
 	default boolean panelAutocomplete()
 	{
@@ -175,10 +148,11 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
+		position = 2,
 		keyName = SHOW_FEEDBACK_TEXTBOX,
 		name = "Show Feedback Textbox",
-		description = "Show a textbox on the prediction feedback panel where you can explain your feedback to us."
+		description = "Show a textbox on the prediction feedback panel where you can explain your feedback to us.",
+		section = panelSection
 	)
 	default boolean showFeedbackTextbox()
 	{
@@ -186,10 +160,11 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 13,
+		position = 3,
 		keyName = "panelDefaultStatsType",
 		name = "Panel Default Stats Tab",
-		description = "Sets the initial player statistics tab in the prediction panel for when the plugin is launched."
+		description = "Sets the initial player statistics tab in the prediction panel for when the plugin is launched.",
+		section = panelSection
 	)
 	default PlayerStatsType panelDefaultStatsType()
 	{
@@ -197,10 +172,11 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 4,
 		keyName = PANEL_FONT_TYPE_KEY,
 		name = "Panel Font Size",
-		description = "Sets the size of the label fields in the prediction panel."
+		description = "Sets the size of the label fields in the prediction panel.",
+		section = panelSection
 	)
 	default PanelFontType panelFontType()
 	{
@@ -208,14 +184,82 @@ public interface BotDetectorConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
-		keyName = ANONYMOUS_UPLOADING_KEY,
-		name = "Anonymous Uploading",
-		description = "Your name will not be included with your name uploads.<br>Disable if you'd like to track your contributions."
+		position = 1,
+		keyName = ADD_PREDICT_OPTION_KEY,
+		name = "Right-click 'Predict' Players",
+		description = "Adds an entry to player menus to quickly check them in the prediction panel.",
+		section = predictSection
 	)
-	default boolean enableAnonymousUploading()
+	default boolean addPredictOption()
 	{
-		return true;
+		return false;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "predictOnReport",
+		name = "'Predict' on Right-click 'Report'",
+		description = "Makes the in-game right-click 'Report' option also open the prediction panel.",
+		section = predictSection
+	)
+	default boolean predictOnReport()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 3,
+		keyName = "predictOptionCopyName",
+		name = "'Predict' Copy Name to Clipboard",
+		description = "Copies the player's name to the clipboard when right-click predicting a player.",
+		section = predictSection
+	)
+	default boolean predictOptionCopyName()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "predictOptionDefaultColor",
+		name = "'Predict' Default Color",
+		description = "When right-clicking on a player, the predict option will be this color by default.",
+		section = predictSection
+	)
+	Color predictOptionDefaultColor();
+
+	@ConfigItem(
+		position = 5,
+		keyName = "predictOptionFlaggedColor",
+		name = "'Predict' Voted/Flagged Color",
+		description = "When right-clicking on a player that has been flagged or given feedback, the predict option will be this color instead.",
+		section = predictSection
+	)
+	Color predictOptionFlaggedColor();
+
+	@ConfigItem(
+		position = 1,
+		keyName = "enableChatNotifications",
+		name = "Enable Chat Status Messages",
+		description = "Show various plugin status messages in the game chat.",
+		section = miscSection
+	)
+	default boolean enableChatStatusMessages()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 2,
+		keyName = "statsChatCommandDetailLevel",
+		name = "'!bdstats' Chat Command Detail Level",
+		description = "Enable processing the '!bdstats' command when it appears in the chatbox,"
+			+ "<br>which will fetch the message author's plugin stats and display them.",
+		section = miscSection
+	)
+	default StatsCommandDetailLevel statsChatCommandDetailLevel()
+	{
+		return StatsCommandDetailLevel.CONFIRMED_ONLY;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Changes the config panel to be better organised. The Readme's FAQ section is also reordered to match the new config.

![image](https://user-images.githubusercontent.com/45152844/128577299-fcf51049-e98a-48d4-8095-f2b5d75917ea.png)
