### PR TITLE
Treat players with invalid names as logged out, don't process invalid names

### DIFF
--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -117,7 +117,11 @@ public class BotDetectorPanel extends PluginPanel
 				+ "<br>Your tallies will not increase from seeing players in this world.</html>"),
 		PLAYER_STATS_ERROR(Icons.ERROR_ICON, " Could Not Retrieve Statistics",
 			"<html>Your player statistics could not be retrieved at this time."
-				+ "<br>Either the server could not assign you an ID or the server is down at the moment.</html>")
+				+ "<br>Either the server could not assign you an ID or the server is down at the moment.</html>"),
+		NAME_ERROR(Icons.ERROR_ICON, " Invalid Player Name",
+			"<html>Your player name could not be loaded correctly."
+				+ "<br>Most likely you spawned on Tutorial Island or your name was forcibly reset by Jagex."
+				+ "<br>Try relogging after setting a name.</html>")
 		;
 
 		private final Icon image;


### PR DESCRIPTION
Should hopefully fix players starting on tutorial island and filter out invalid names for uploads as well.

![image](https://user-images.githubusercontent.com/45152844/131902848-c64885c8-0e29-419e-9c2d-c9ff13390295.png)
