### PR TITLE
Small refactor for Spinner Icons on the panel

### DIFF
--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -146,7 +146,6 @@ public class BotDetectorPanel extends PluginPanel
 	private static final Color NEGATIVE_BUTTON_COLOR = ColorScheme.PROGRESS_ERROR_COLOR;
 
 	private static final String EMPTY_LABEL = "---";
-	private static final String LOADING_SPINNER_PATH = "loading_spinner_darker.gif";
 
 	private static final int HEADER_PAD = 3;
 	private static final int WARNING_PAD = 5;
@@ -1014,9 +1013,7 @@ public class BotDetectorPanel extends PluginPanel
 	public void setPlayerStatsLoading(boolean loading)
 	{
 		statsLoading = loading;
-		playerStatsHeaderLabel.setIcon(loading ?
-			new ImageIcon(Objects.requireNonNull(getClass().getResource(LOADING_SPINNER_PATH)))
-			: null);
+		playerStatsHeaderLabel.setIcon(loading ? Icons.LOADING_SPINNER_SUPPLIER.get() : null);
 	}
 
 	/**
@@ -1343,7 +1340,7 @@ public class BotDetectorPanel extends PluginPanel
 			plugin.getFeedbackedPlayersText().put(wrappedName, feedbackText);
 		}
 
-		feedbackHeaderLabel.setIcon(new ImageIcon(Objects.requireNonNull(getClass().getResource(LOADING_SPINNER_PATH))));
+		feedbackHeaderLabel.setIcon(Icons.LOADING_SPINNER_SUPPLIER.get());
 		detectorClient.sendFeedback(lastPrediction, lastPredictionUploaderName, proposedLabel, feedbackText)
 			.whenComplete((b, ex) ->
 			{
@@ -1399,7 +1396,7 @@ public class BotDetectorPanel extends PluginPanel
 			return;
 		}
 
-		flaggingHeaderLabel.setIcon(new ImageIcon(Objects.requireNonNull(getClass().getResource(LOADING_SPINNER_PATH))));
+		flaggingHeaderLabel.setIcon(Icons.LOADING_SPINNER_SUPPLIER.get());
 		detectorClient.sendSighting(lastPredictionPlayerSighting, lastPredictionUploaderName, true)
 			.whenComplete((b, ex) ->
 			{

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -1013,7 +1013,7 @@ public class BotDetectorPanel extends PluginPanel
 	public void setPlayerStatsLoading(boolean loading)
 	{
 		statsLoading = loading;
-		playerStatsHeaderLabel.setIcon(loading ? Icons.LOADING_SPINNER_SUPPLIER.get() : null);
+		playerStatsHeaderLabel.setIcon(loading ? Icons.LOADING_SPINNER : null);
 	}
 
 	/**
@@ -1340,7 +1340,7 @@ public class BotDetectorPanel extends PluginPanel
 			plugin.getFeedbackedPlayersText().put(wrappedName, feedbackText);
 		}
 
-		feedbackHeaderLabel.setIcon(Icons.LOADING_SPINNER_SUPPLIER.get());
+		feedbackHeaderLabel.setIcon(Icons.LOADING_SPINNER);
 		detectorClient.sendFeedback(lastPrediction, lastPredictionUploaderName, proposedLabel, feedbackText)
 			.whenComplete((b, ex) ->
 			{
@@ -1396,7 +1396,7 @@ public class BotDetectorPanel extends PluginPanel
 			return;
 		}
 
-		flaggingHeaderLabel.setIcon(Icons.LOADING_SPINNER_SUPPLIER.get());
+		flaggingHeaderLabel.setIcon(Icons.LOADING_SPINNER);
 		detectorClient.sendSighting(lastPredictionPlayerSighting, lastPredictionUploaderName, true)
 			.whenComplete((b, ex) ->
 			{

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -55,7 +55,6 @@ import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.inject.Inject;

--- a/src/main/java/com/botdetector/ui/Icons.java
+++ b/src/main/java/com/botdetector/ui/Icons.java
@@ -25,6 +25,8 @@
  */
 package com.botdetector.ui;
 
+import java.util.Objects;
+import java.util.function.Supplier;
 import javax.swing.ImageIcon;
 import net.runelite.client.util.ImageUtil;
 
@@ -39,4 +41,8 @@ public class Icons
 	public static final ImageIcon TWITTER_ICON = new ImageIcon(ImageUtil.loadImageResource(PLUGIN_CLASS, "twitter.png"));
 	public static final ImageIcon WARNING_ICON = new ImageIcon(ImageUtil.loadImageResource(PLUGIN_CLASS, "warning.png"));
 	public static final ImageIcon ERROR_ICON = new ImageIcon(ImageUtil.loadImageResource(PLUGIN_CLASS, "error.png"));
+
+	// Has to be a supplier as a new instance needs to be created every time for the animation to work properly
+	public static final Supplier<ImageIcon> LOADING_SPINNER_SUPPLIER = () ->
+		new ImageIcon(Objects.requireNonNull(PLUGIN_CLASS.getResource("loading_spinner_darker.gif")));
 }

--- a/src/main/java/com/botdetector/ui/Icons.java
+++ b/src/main/java/com/botdetector/ui/Icons.java
@@ -26,7 +26,6 @@
 package com.botdetector.ui;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 import javax.swing.ImageIcon;
 import net.runelite.client.util.ImageUtil;
 
@@ -42,7 +41,6 @@ public class Icons
 	public static final ImageIcon WARNING_ICON = new ImageIcon(ImageUtil.loadImageResource(PLUGIN_CLASS, "warning.png"));
 	public static final ImageIcon ERROR_ICON = new ImageIcon(ImageUtil.loadImageResource(PLUGIN_CLASS, "error.png"));
 
-	// Has to be a supplier as a new instance needs to be created every time for the animation to work properly
-	public static final Supplier<ImageIcon> LOADING_SPINNER_SUPPLIER = () ->
-		new ImageIcon(Objects.requireNonNull(PLUGIN_CLASS.getResource("loading_spinner_darker.gif")));
+	// Must not be ImageUtil.loadImageResource as it produces a static image
+	public static final ImageIcon LOADING_SPINNER = new ImageIcon(Objects.requireNonNull(PLUGIN_CLASS.getResource("loading_spinner_darker.gif")));
 }


### PR DESCRIPTION
Does not affect functionality, just a bit of tidying up. Originally used a supplier to ensure a new instance of the icon every time, but it seems this is unnecessary. Just make sure everything spins good, not a priority at all however.