### PR TITLE
Tweak null confidence case to allow populating feedback label list

### DIFF
--- a/src/main/java/com/botdetector/http/BotDetectorClient.java
+++ b/src/main/java/com/botdetector/http/BotDetectorClient.java
@@ -359,13 +359,13 @@ public class BotDetectorClient
 
 	/**
 	 * Requests a bot prediction for the given {@code playerName}.
-	 * Breakdown will not be provided in special cases (see {@link BotDetectorClient#requestPrediction(String, boolean)}).
+	 * Breakdown will be provided by default in special cases (see {@link BotDetectorClient#requestPrediction(String, boolean)}).
 	 * @param playerName The player name to predict.
 	 * @return A future that will eventually return the player's bot prediction.
 	 */
 	public CompletableFuture<Prediction> requestPrediction(String playerName)
 	{
-		return requestPrediction(playerName, false);
+		return requestPrediction(playerName, true);
 	}
 
 	/**

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -1103,8 +1103,7 @@ public class BotDetectorPanel extends PluginPanel
 			feedbackLabelComboBox.setSelectedItem(UNSURE_PREDICTION_LABEL);
 			feedbackLabelComboBox.addItem(SOMETHING_ELSE_PREDICTION_LABEL);
 
-			if (pred.getPredictionBreakdown() == null || pred.getPredictionBreakdown().size() == 0
-				|| (isNullConfidence && !config.showBreakdownOnNullConfidence()))
+			if (pred.getPredictionBreakdown() == null || pred.getPredictionBreakdown().size() == 0)
 			{
 				predictionBreakdownLabel.setText(EMPTY_LABEL);
 				predictionBreakdownPanel.setVisible(false);
@@ -1113,8 +1112,16 @@ public class BotDetectorPanel extends PluginPanel
 			}
 			else
 			{
-				predictionBreakdownLabel.setText(toPredictionBreakdownString(pred.getPredictionBreakdown()));
-				predictionBreakdownPanel.setVisible(true);
+				if (isNullConfidence && !config.showBreakdownOnNullConfidence())
+				{
+					predictionBreakdownLabel.setText(EMPTY_LABEL);
+					predictionBreakdownPanel.setVisible(false);
+				}
+				else
+				{
+					predictionBreakdownLabel.setText(toPredictionBreakdownString(pred.getPredictionBreakdown()));
+					predictionBreakdownPanel.setVisible(true);
+				}
 
 				final String primaryLabel = pred.getPredictionLabel();
 
@@ -1272,9 +1279,7 @@ public class BotDetectorPanel extends PluginPanel
 
 		setPrediction(null);
 
-		// Note: The showBreakdown parameter is redundant due to the null confidence checks added, but we're including it for now.
-		// If to be removed, ensure the API breakdown parameter is always true.
-		detectorClient.requestPrediction(target, config.showBreakdownOnNullConfidence()).whenCompleteAsync((pred, ex) ->
+		detectorClient.requestPrediction(target).whenCompleteAsync((pred, ex) ->
 			SwingUtilities.invokeLater(() ->
 			{
 				if (!sanitize(searchBar.getText()).equals(target))


### PR DESCRIPTION
Tweak to allow the feedback combobox to still be populated when Stats Too Low.

Instead of telling the API to not send a breakdown, the breakdown is now always requested, but hidden on the plugin side if confidence is null. The combobox can still be populated from the hidden breakdown.