### PR TITLE
Fix for when prediction breakdown does not contain main label

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -680,7 +680,7 @@ public class BotDetectorPlugin extends Plugin
 
 		String rawName = player.getName();
 
-		boolean invalidName = rawName == null || rawName.length() == 0 || rawName.charAt(0) == '#' || rawName.charAt(0) == '[';
+		boolean invalidName = rawName == null || rawName.isEmpty() || rawName.charAt(0) == '#' || rawName.charAt(0) == '[';
 
 		if (player == client.getLocalPlayer())
 		{

--- a/src/main/java/com/botdetector/http/BotDetectorClient.java
+++ b/src/main/java/com/botdetector/http/BotDetectorClient.java
@@ -398,7 +398,17 @@ public class BotDetectorClient
 			{
 				try
 				{
-					future.complete(processResponse(gson, response, Prediction.class));
+					Prediction p = processResponse(gson, response, Prediction.class);
+					// Sanity check
+					if (p != null && p.getPredictionBreakdown() != null && !p.getPredictionBreakdown().isEmpty())
+					{
+						if (p.getPredictionBreakdown().keySet().stream()
+							.noneMatch(x -> p.getPredictionLabel().equalsIgnoreCase(x)))
+						{
+							p.getPredictionBreakdown().put(p.getPredictionLabel(), p.getConfidence());
+						}
+					}
+					future.complete(p);
 				}
 				catch (IOException e)
 				{

--- a/src/main/java/com/botdetector/http/BotDetectorClient.java
+++ b/src/main/java/com/botdetector/http/BotDetectorClient.java
@@ -399,13 +399,15 @@ public class BotDetectorClient
 				try
 				{
 					Prediction p = processResponse(gson, response, Prediction.class);
-					// Sanity check
+					// Sanity check for if the primary label does not appear in the breakdown
 					if (p != null && p.getPredictionBreakdown() != null && !p.getPredictionBreakdown().isEmpty())
 					{
 						if (p.getPredictionBreakdown().keySet().stream()
 							.noneMatch(x -> p.getPredictionLabel().equalsIgnoreCase(x)))
 						{
 							p.getPredictionBreakdown().put(p.getPredictionLabel(), p.getConfidence());
+							log.warn(String.format("Primary prediction label missing from breakdown! Added missing label. (pl:'%s', id:'%d', lb:'%s', cf:'%.4f')",
+								p.getPlayerName(), p.getPlayerId(), p.getPredictionLabel(), p.getConfidence()));
 						}
 					}
 					future.complete(p);

--- a/src/main/java/com/botdetector/http/BotDetectorClient.java
+++ b/src/main/java/com/botdetector/http/BotDetectorClient.java
@@ -400,15 +400,15 @@ public class BotDetectorClient
 				{
 					Prediction p = processResponse(gson, response, Prediction.class);
 					// Sanity check for if the primary label does not appear in the breakdown
-					if (p != null && p.getPredictionBreakdown() != null && !p.getPredictionBreakdown().isEmpty())
+					if (p != null
+						&& p.getConfidence() != null // Some 'debug' labels such as 'Stats_Too_Low' will have null confidence, ignore these!
+						&& p.getPredictionBreakdown() != null
+						&& !p.getPredictionBreakdown().isEmpty()
+						&& p.getPredictionBreakdown().keySet().stream().noneMatch(x -> p.getPredictionLabel().equalsIgnoreCase(x)))
 					{
-						if (p.getPredictionBreakdown().keySet().stream()
-							.noneMatch(x -> p.getPredictionLabel().equalsIgnoreCase(x)))
-						{
-							p.getPredictionBreakdown().put(p.getPredictionLabel(), p.getConfidence());
-							log.warn(String.format("Primary prediction label missing from breakdown! Added missing label. (pl:'%s', id:'%d', lb:'%s', cf:'%.4f')",
-								p.getPlayerName(), p.getPlayerId(), p.getPredictionLabel(), p.getConfidence()));
-						}
+						p.getPredictionBreakdown().put(p.getPredictionLabel(), p.getConfidence());
+						log.warn(String.format("Primary prediction label missing from breakdown! Added missing label. (pl:'%s', id:'%d', lb:'%s', cf:'%.4f')",
+							p.getPlayerName(), p.getPlayerId(), p.getPredictionLabel(), p.getConfidence()));
 					}
 					future.complete(p);
 				}

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -1253,7 +1253,7 @@ public class BotDetectorPanel extends PluginPanel
 	{
 		String target = sanitize(searchBar.getText());
 
-		if (target.length() <= 0)
+		if (target.isEmpty())
 		{
 			return;
 		}
@@ -1654,7 +1654,7 @@ public class BotDetectorPanel extends PluginPanel
 	 */
 	private static String toPredictionBreakdownString(Map<String, Double> predictionMap)
 	{
-		if (predictionMap == null || predictionMap.size() == 0)
+		if (predictionMap == null || predictionMap.isEmpty())
 		{
 			return null;
 		}

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -1107,7 +1107,7 @@ public class BotDetectorPanel extends PluginPanel
 			feedbackLabelComboBox.setSelectedItem(UNSURE_PREDICTION_LABEL);
 			feedbackLabelComboBox.addItem(SOMETHING_ELSE_PREDICTION_LABEL);
 
-			if (pred.getPredictionBreakdown() == null || pred.getPredictionBreakdown().size() == 0)
+			if (pred.getPredictionBreakdown() == null || pred.getPredictionBreakdown().isEmpty())
 			{
 				predictionBreakdownLabel.setText(EMPTY_LABEL);
 				predictionBreakdownPanel.setVisible(false);
@@ -1133,7 +1133,7 @@ public class BotDetectorPanel extends PluginPanel
 					entry ->
 					{
 						FeedbackPredictionLabel pLabel = new FeedbackPredictionLabel(entry.getKey(), entry.getValue(),
-							entry.getKey().equals(primaryLabel) ? FeedbackValue.POSITIVE : FeedbackValue.NEGATIVE);
+							entry.getKey().equalsIgnoreCase(primaryLabel) ? FeedbackValue.POSITIVE : FeedbackValue.NEGATIVE);
 						feedbackLabelComboBox.addItem(pLabel);
 						if (pLabel.getFeedbackValue() == FeedbackValue.POSITIVE)
 						{


### PR DESCRIPTION
If the API returns a breakdown with at least one element and that breakdown does not contain the primary label, it is added before being sent over to the plugin. Ideally this should not happen, this is more of a fallback measure.

Also some random changes to using `isEmpty()` in there, I'm not sure why I didn't use those before.