### PR TITLE
Update README badges to api.runelite.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bot Detector Plugin
 ![GitHub](https://img.shields.io/github/license/Bot-Detector/bot-detector)
-[![](https://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/rank/plugin/bot-detector)](https://runelite.net/plugin-hub) [![](https://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/bot-detector)](https://runelite.net/plugin-hub) 
+[![](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/bot-detector)](https://runelite.net/plugin-hub) [![](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/bot-detector)](https://runelite.net/plugin-hub) 
 ![Website](https://img.shields.io/website?down_color=lightgrey&down_message=down&up_color=green&up_message=up&url=https%3A%2F%2Fosrsbotdetector.com%2F)
 ![Discord](https://img.shields.io/discord/817916789668708384?label=discord)
 ![Twitter Follow](https://img.shields.io/twitter/follow/osrsbotdetector?style=social)


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/bot-detector) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: