### PR TITLE
Self hiding panel button

### DIFF
--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -229,8 +229,8 @@ public interface BotDetectorConfig extends Config
 		keyName = HIDE_PANEL_NAVIGATION_BUTTON_KEY,
 		name = "Hide Panel Navigation Button",
 		description = "Hides the panel navigation button on the Runelite sidebar when not in use.",
-		warning = "If the panel navigation button is hidden, the only way to use the plugin side panel is to use some" +
-			"<br>variation of right-click 'Predict' option or to input the <b>::BDOpenSidePanel</b> command in chat.",
+		warning = "<html>If the panel navigation button is hidden, the only way to use the plugin side panel is to use some variation" +
+			"<br>of the right-click 'Predict' option or to input the <b>::BDOpenPanel</b> or <b>::BDOpen</b> command in chat.</html>",
 		section = panelSection
 	)
 	default boolean hidePanelNavigationButton()

--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -229,7 +229,8 @@ public interface BotDetectorConfig extends Config
 		keyName = HIDE_PANEL_NAVIGATION_BUTTON_KEY,
 		name = "Hide Panel Navigation Button",
 		description = "Hides the panel navigation button on the Runelite sidebar when not in use.",
-		warning = "<html>If the panel navigation button is hidden, the only way to use the plugin side panel is to use some variation" +
+		warning = "<html><span style='color:red'>WARNING:</span> This feature is experimental, please report any issues on our github!" +
+			"<br><br>If the panel navigation button is hidden, the only way to use the plugin side panel is to use some variation" +
 			"<br>of the right-click 'Predict' option or to input the <b>::BDOpenPanel</b> or <b>::BDOpen</b> command in chat.</html>",
 		section = panelSection
 	)

--- a/src/main/java/com/botdetector/BotDetectorConfig.java
+++ b/src/main/java/com/botdetector/BotDetectorConfig.java
@@ -52,6 +52,8 @@ public interface BotDetectorConfig extends Config
 	String ANONYMOUS_UUID_KEY = "anonymousUUID";
 	String ACKNOWLEDGED_HARASSMENT_WARNING_KEY = "acknowledgedHarassmentWarning";
 
+	String HIDE_PANEL_NAVIGATION_BUTTON_KEY = "hidePanelNavigationButton";
+
 	int AUTO_SEND_MINIMUM_MINUTES = 5;
 	int AUTO_SEND_MAXIMUM_MINUTES = 360;
 
@@ -220,6 +222,20 @@ public interface BotDetectorConfig extends Config
 	default PanelFontType panelFontType()
 	{
 		return PanelFontType.NORMAL;
+	}
+
+	@ConfigItem(
+		position = 6,
+		keyName = HIDE_PANEL_NAVIGATION_BUTTON_KEY,
+		name = "Hide Panel Navigation Button",
+		description = "Hides the panel navigation button on the Runelite sidebar when not in use.",
+		warning = "If the panel navigation button is hidden, the only way to use the plugin side panel is to use some" +
+			"<br>variation of right-click 'Predict' option or to input the <b>::BDOpenSidePanel</b> command in chat.",
+		section = panelSection
+	)
+	default boolean hidePanelNavigationButton()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -25,6 +25,7 @@
  */
 package com.botdetector;
 
+import com.botdetector.events.BotDetectorPanelDeactivated;
 import com.botdetector.http.BotDetectorClient;
 import com.botdetector.http.UnauthorizedTokenException;
 import com.botdetector.http.ValidationException;
@@ -350,7 +351,10 @@ public class BotDetectorPlugin extends Plugin
 			.priority(90)
 			.build();
 
-		clientToolbar.addNavigation(navButton);
+		if (!config.hidePanelNavigationButton())
+		{
+			clientToolbar.addNavigation(navButton);
+		}
 
 		if (config.addPredictPlayerOption() && client != null)
 		{
@@ -588,6 +592,15 @@ public class BotDetectorPlugin extends Plugin
 	}
 
 	@Subscribe
+	private void onBotDetectorPanelDeactivated(BotDetectorPanelDeactivated event)
+	{
+		if (config.hidePanelNavigationButton())
+		{
+			clientToolbar.removeNavigation(navButton);
+		}
+	}
+
+	@Subscribe
 	private void onConfigChanged(ConfigChanged event)
 	{
 		if (!event.getGroup().equals(BotDetectorConfig.CONFIG_GROUP) || event.getKey() == null)
@@ -631,6 +644,16 @@ public class BotDetectorPlugin extends Plugin
 			case BotDetectorConfig.AUTO_SEND_MINUTES_KEY:
 			case BotDetectorConfig.ONLY_SEND_AT_LOGOUT_KEY:
 				updateTimeToAutoSend();
+				break;
+			case BotDetectorConfig.HIDE_PANEL_NAVIGATION_BUTTON_KEY:
+				if (config.hidePanelNavigationButton())
+				{
+					clientToolbar.removeNavigation(navButton);
+				}
+				else
+				{
+					clientToolbar.addNavigation(navButton);
+				}
 				break;
 		}
 	}
@@ -1088,11 +1111,8 @@ public class BotDetectorPlugin extends Plugin
 	 */
 	public void predictPlayer(String playerName)
 	{
-		SwingUtilities.invokeLater(() ->
-		{
-			clientToolbar.openPanel(navButton);
-			panel.predictPlayer(playerName);
-		});
+		openSidePanel();
+		SwingUtilities.invokeLater(() -> panel.predictPlayer(playerName));
 	}
 
 	/**
@@ -1391,6 +1411,19 @@ public class BotDetectorPlugin extends Plugin
 		{
 			sendChatStatusMessage("Discord verification errors will no longer be shown in the chat", true);
 		}
+	}
+
+	/**
+	 * Forces the side panel to open
+	 */
+	private void openSidePanel()
+	{
+		if (config.hidePanelNavigationButton())
+		{
+			clientToolbar.addNavigation(navButton);
+		}
+
+		SwingUtilities.invokeLater(() -> clientToolbar.openPanel(navButton));
 	}
 
 	//endregion

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -168,6 +168,8 @@ public class BotDetectorPlugin extends Plugin
 	private static final String CLEAR_AUTH_TOKEN_COMMAND = COMMAND_PREFIX + "ClearToken";
 	private static final String TOGGLE_SHOW_DISCORD_VERIFICATION_ERRORS_COMMAND = COMMAND_PREFIX + "ToggleShowDiscordVerificationErrors";
 	private static final String TOGGLE_SHOW_DISCORD_VERIFICATION_ERRORS_COMMAND_ALIAS = COMMAND_PREFIX + "ToggleDVE";
+	private static final String OPEN_PANEL_COMMAND = COMMAND_PREFIX + "OpenPanel";
+	private static final String OPEN_PANEL_COMMAND_ALIAS = COMMAND_PREFIX + "Open";
 
 	/** Command to method map to be used in {@link #onCommandExecuted(CommandExecuted)}. **/
 	private final ImmutableMap<CaseInsensitiveString, Consumer<String[]>> commandConsumerMap =
@@ -181,6 +183,8 @@ public class BotDetectorPlugin extends Plugin
 			.put(wrap(CLEAR_AUTH_TOKEN_COMMAND), s -> clearAuthTokenCommand())
 			.put(wrap(TOGGLE_SHOW_DISCORD_VERIFICATION_ERRORS_COMMAND), s -> toggleShowDiscordVerificationErrors())
 			.put(wrap(TOGGLE_SHOW_DISCORD_VERIFICATION_ERRORS_COMMAND_ALIAS), s -> toggleShowDiscordVerificationErrors())
+			.put(wrap(OPEN_PANEL_COMMAND), s -> openSidePanel())
+			.put(wrap(OPEN_PANEL_COMMAND_ALIAS), s -> openSidePanel())
 			.build();
 
 	private static final int MANUAL_FLUSH_COOLDOWN_SECONDS = 60;

--- a/src/main/java/com/botdetector/BotDetectorPlugin.java
+++ b/src/main/java/com/botdetector/BotDetectorPlugin.java
@@ -1418,10 +1418,15 @@ public class BotDetectorPlugin extends Plugin
 	}
 
 	/**
-	 * Forces the side panel to open
+	 * Opens the side panel if it's not already open
 	 */
 	private void openSidePanel()
 	{
+		if (panel.isActive())
+		{
+			return;
+		}
+
 		if (config.hidePanelNavigationButton())
 		{
 			clientToolbar.addNavigation(navButton);

--- a/src/main/java/com/botdetector/events/BotDetectorPanelDeactivated.java
+++ b/src/main/java/com/botdetector/events/BotDetectorPanelDeactivated.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Ferrariic, Seltzer Bro, Cyborger1
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.botdetector.events;
+
+/**s
+ * Event for when the {@link com.botdetector.ui.BotDetectorPanel} is deactivated.
+ */
+public class BotDetectorPanelDeactivated
+{
+}

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -298,19 +298,14 @@ public class BotDetectorPanel extends PluginPanel
 	@Override
 	public void onActivate()
 	{
-		eventBus.post(new BotDetectorPanelActivated());
 		isActive = true;
+		eventBus.post(new BotDetectorPanelActivated());
 	}
 
 	@Override
 	public void onDeactivate()
 	{
 		isActive = false;
-	}
-
-	@Override
-	public void onDeactivate()
-	{
 		eventBus.post(new BotDetectorPanelDeactivated());
 	}
 

--- a/src/main/java/com/botdetector/ui/BotDetectorPanel.java
+++ b/src/main/java/com/botdetector/ui/BotDetectorPanel.java
@@ -29,6 +29,7 @@ import com.botdetector.BotDetectorConfig;
 import com.botdetector.BotDetectorPlugin;
 import static com.botdetector.BotDetectorPlugin.normalizeAndWrapPlayerName;
 import com.botdetector.events.BotDetectorPanelActivated;
+import com.botdetector.events.BotDetectorPanelDeactivated;
 import com.botdetector.http.BotDetectorClient;
 import com.botdetector.model.CaseInsensitiveString;
 import com.botdetector.model.FeedbackValue;
@@ -305,6 +306,12 @@ public class BotDetectorPanel extends PluginPanel
 	public void onDeactivate()
 	{
 		isActive = false;
+	}
+
+	@Override
+	public void onDeactivate()
+	{
+		eventBus.post(new BotDetectorPanelDeactivated());
 	}
 
 	/**


### PR DESCRIPTION
This is some fixed up code I had from over a year ago for a self hiding side panel button. Putting this here as I've seen an issue for this pop up earlier.

Draft until I can test this properly. Previously this was extremely janky, but changes to the `clientToolbar` class on Runelite's side seem to have made this stable at first glance.

I'm considering just putting this in with a big ol' warning on the config setting that warns this feature is experimental and could be slightly unstable.

Should resolve https://github.com/Bot-detector/bot-detector/issues/187